### PR TITLE
Electron

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash
 
       - name: Create addon file
-        run: npm ci
+        run: yarn gyp-rebuild
 
       - name: Export addon file name
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*.*.*'
 env:
+  node_version: 14
+  electron_version: 13.6.3
   export_cmd: |
     GIT_TAG=$(echo ${GITHUB_REF#refs/*/} | cut -d 'v' -f 2)
     PKG_VERSION=$(echo $(node -p "JSON.stringify(require('./package.json').version)") | sed 's|"||g')
@@ -23,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1.4.6
         with:
-          node-version: 12
+          node-version: ${{ env.node_version }}
 
       - name: Export git tag and package.json version
         run: ${{ env.export_cmd }}
@@ -63,7 +65,7 @@ jobs:
         uses: actions/setup-node@v1.4.6
         with:
           registry-url: 'https://registry.npmjs.org'
-          node-version: 12
+          node-version: ${{ env.node_version }}
 
       - name: Export git tag and package.json version
         run: ${{ env.export_cmd }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**'
 
+env:
+  node_version: 14.16.0
+
 jobs:
   macos-debug:
     name: MacOS Tests
@@ -16,6 +19,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v1.4.6
+        with:
+          node-version: ${{ env.node_version }}
       - name: Setup Debug Build
         run: cmake -S . -B cmake-build-debug
       - name: Build Debug Build
@@ -23,17 +30,12 @@ jobs:
       - name: Run Tests
         working-directory: cmake-build-debug/src/tests/
         run: ./omega_test -d yes --order lex
-      - name: Create Node v12 Virtual Environment
-        run: nodeenv --node=12.22.8 venv
-      - name: Prepare To Build Node v12 Bindings
+      - name: Prepare To Build Node v14 Bindings
         run: |
-          source ./venv/bin/activate
           npm ci
           mv module/omega_edit* module/omega_edit.node
-      - name: Test Node v12 Bindings
-        run: |
-          source ./venv/bin/activate
-          node ./src/examples/omega_simple.js
+      - name: Test Node v14 Bindings
+        run: node ./src/examples/omega_simple.js
 
   linux-debug:
     name: Linux Tests
@@ -45,6 +47,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v1.4.6
+        with:
+          node-version: ${{ env.node_version }}
       - name: Setup Debug Build
         run: cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_C_FLAGS=--coverage
       - name: Build Debug Build
@@ -58,14 +64,9 @@ jobs:
       - name: Run Tests Under Valgrind
         working-directory: cmake-build-debug/src/tests/
         run: valgrind --leak-check=full --show-leak-kinds=all --leak-resolution=med --track-origins=yes --vgdb=no --error-exitcode=1 ./omega_test -d yes --order lex
-      - name: Create Node v12 Virtual Environment
-        run: nodeenv --node=12.22.8 venv
-      - name: Prepare To Build Node v12 Bindings
+      - name: Prepare To Build Node v14 Bindings
         run: |
-          source ./venv/bin/activate
           npm ci
           mv module/omega_edit* module/omega_edit.node
-      - name: Test Node v12 Bindings
-        run: |
-          source ./venv/bin/activate
-          node ./src/examples/omega_simple.js
+      - name: Test Node v14 Bindings
+        run: node ./src/examples/omega_simple.js

--- a/README.md
+++ b/README.md
@@ -57,20 +57,20 @@ cd ../../../
 
 ## Build Node bindings
 
-The SWIG bindings are generated for Node v12, so we need to setup the environment accordingly.  There are several reasonable ways to do this.  Here are two options:
+The SWIG bindings are generated for Node v14, so we need to setup the environment accordingly.  There are several reasonable ways to do this.  Here are two options:
 
 #### **OPTION 1:** Use nvm ([Node Version Manager](https://github.com/nvm-sh/nvm))
 
-Using Node v12 in nvm looks like this:
+Using Node v14 in nvm looks like this:
 
 ```bash
-nvm use 12
+nvm use 14
 ```
 
-#### **OPTION 2:** Setup a Node v12 virtual environment using [nodeenv](https://pypi.org/project/nodeenv/)
+#### **OPTION 2:** Setup a Node v14 virtual environment using [nodeenv](https://pypi.org/project/nodeenv/)
 
 ```bash
-nodeenv --node=12.22.8 venv
+nodeenv --node=14.16.0 venv
 ```
 
 Activate the Node virtual environment:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.2-2",
+  "version": "0.6.2",
   "main": "module/index.js",
   "repository": {
     "url": "https://github.com/scholarsmate/omega-edit",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.2-1",
+  "version": "0.6.2-2",
   "main": "module/index.js",
   "repository": {
     "url": "https://github.com/scholarsmate/omega-edit",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "gyp-remove": "node-gyp remove",
     "swig-compile": "swig -javascript -node -v -c++ src/bindings/omega_edit.i",
     "pre-package": "yarn swig-compile && yarn gyp-configure && yarn gyp-build",
-    "package": "yarn pre-package && yarn publish"
+    "package": "yarn pre-package && yarn pack"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omega-edit",
   "description": "OmegaEdit open source library for building editors that can handle massive files",
-  "version": "0.6.2",
+  "version": "0.6.2-1",
   "main": "module/index.js",
   "repository": {
     "url": "https://github.com/scholarsmate/omega-edit",
@@ -13,11 +13,11 @@
   "author": "Shane Dell, Davin Shearer, John Wass",
   "license": "Apache-2.0",
   "scripts": {
-    "gyp-build": "node-gyp build",
-    "gyp-clean": "node-gyp clean",
-    "gyp-configure": "node-gyp configure",
-    "gyp-rebuild": "node-gyp rebuild",
-    "gyp-install": "node-gyp install",
+    "gyp-build": "node-gyp build --target=13.6.3 --dist-url=https://electronjs.org/headers",
+    "gyp-clean": "node-gyp clean --target=13.6.3 --dist-url=https://electronjs.org/headers",
+    "gyp-configure": "node-gyp configure --target=13.6.3 --dist-url=https://electronjs.org/headers",
+    "gyp-rebuild": "node-gyp rebuild --target=13.6.3 --dist-url=https://electronjs.org/headers",
+    "gyp-install": "node-gyp install --target=13.6.3 --dist-url=https://electronjs.org/headers",
     "gyp-list": "node-gyp list",
     "gyp-remove": "node-gyp remove",
     "swig-compile": "swig -javascript -node -v -c++ src/bindings/omega_edit.i",


### PR DESCRIPTION
- Updated release.yml to build the addon files using electron
  - This is needed for us to be able to import the package in VSCode.
- Updated unit tests CI so that it should run quicker.
- Updated nodejs to 14
  - This was to line up versions. As 14.16.0 is what used by the electron version required to work with VSCode   